### PR TITLE
[Modify] SearchBar 내 input의 query 존재 여부에 따라 ResetBtn 렌더링 여부 결정 및 SearchBar의 bg-color 변경

### DIFF
--- a/src/components/molecules/SearchBar/SearchBar.jsx
+++ b/src/components/molecules/SearchBar/SearchBar.jsx
@@ -8,7 +8,7 @@ function SearchBar({ query, onQueryChange, onResetClick, pgName }) {
     <form className="bg-primary-50 w-full flex justify-between items-center gap-2 rounded border border-primary-500 px-3 py-2 ">
       <SearchIcon />
       <SearchInput query={query} onChange={onQueryChange} pgName={pgName} />
-      <ResetBtn onClick={onResetClick} />
+      {query === '' ? null : <ResetBtn onClick={onResetClick} />}
     </form>
   );
 }

--- a/src/components/molecules/SearchBar/SearchBar.jsx
+++ b/src/components/molecules/SearchBar/SearchBar.jsx
@@ -5,7 +5,7 @@ import ResetBtn from '../../atoms/ResetBtn/ResetBtn';
 
 function SearchBar({ query, onQueryChange, onResetClick, pgName }) {
   return (
-    <form className="bg-primary-50 w-full flex justify-between items-center gap-2 rounded border border-primary-500 px-3 py-2 ">
+    <form className="bg-grayscale-white w-full flex justify-between items-center gap-2 rounded border border-primary-500 px-3 py-2 ">
       <SearchIcon />
       <SearchInput query={query} onChange={onQueryChange} pgName={pgName} />
       {query === '' ? null : <ResetBtn onClick={onResetClick} />}


### PR DESCRIPTION
## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 내용 요약

- SearchBar 내 SearchInput의 query keyword 존재 여부에 따라 ResetBtn을 렌더링하는 로직 작성
- SearchBar 컴포넌트의 배경 색깔을 primary-50 -> grayscale-white로 변경

### PR 상세

- `Commits` 및 `Files changed` 참고

### 스크린샷

- SearchBar 내 SearchInput의 query keyword 존재 여부에 따라 ResetBtn을 렌더링

  ![Honeycam 2024-11-07 01-26-12](https://github.com/user-attachments/assets/0a1bf967-1906-41de-aab1-6c960c3aa47f)

- SearchBar 컴포넌트의 배경 색깔을 primary-50 -> grayscale-white로 변경

  ![image](https://github.com/user-attachments/assets/f20b2cca-9c3e-42cb-9aba-81d7ffa8fca8)