### PR TITLE
[Feat] PocketBase DB 내 로그인 한 유저의 'users' collection record를 prefetch 하는 기능 추가 외

### DIFF
--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -23,9 +23,6 @@ import FeedDetailPage from './components/pages/FeedDetailPage/FeedDetailPage';
 import { getOneMemosRec } from './utils/controlMemoData';
 import MemoRegistrationPage from './components/pages/MemoRegistrationPage/MemoRegistrationPage';
 
-// 이 코드는 createroutesfromelements 를 사용하도록 수정해 보셔요.
-// 선언형 코드를 작성하면 눈의 피로가 줄어드는 효과가 있었습니다.
-// https://reactrouter.com/en/main/utils/create-routes-from-elements
 const router = createBrowserRouter([
   {
     path: '/',

--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -109,8 +109,6 @@ const router = createBrowserRouter([
       {
         path: 'character',
         element: <CharacterPage />,
-        loader: async () =>
-          await pb.collection('users').getOne(loginUserData.id),
       },
       {
         path: 'mypage',

--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -22,8 +22,6 @@ import FeedRegistrationPage from './components/pages/FeedRegistrationPage/FeedRe
 import FeedDetailPage from './components/pages/FeedDetailPage/FeedDetailPage';
 import { getOneMemosRec } from './utils/controlMemoData';
 import MemoRegistrationPage from './components/pages/MemoRegistrationPage/MemoRegistrationPage';
-import pb from './api/pocketbase';
-import { loginUserData } from './utils/controlUserData';
 
 // 이 코드는 createroutesfromelements 를 사용하도록 수정해 보셔요.
 // 선언형 코드를 작성하면 눈의 피로가 줄어드는 효과가 있었습니다.
@@ -113,8 +111,6 @@ const router = createBrowserRouter([
       {
         path: 'mypage',
         element: <MypagePage />,
-        loader: async () =>
-          await pb.collection('users').getOne(loginUserData.id),
       },
     ],
   },

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -17,7 +17,7 @@ function App() {
         queryFn: getAllUserLibRecs,
       });
 
-      queryClient.prefetch({
+      queryClient.prefetchQuery({
         queryKey: ['users', loginUserData],
         queryFn: getOneUsersRec,
       });

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import SplashPage from '../components/pages/SplashPage/SplashPage';
 import GlobalNavigator from '/src/components/organisms/GlobalNavigator/GlobalNavigator';
-import { loginUserData } from '../utils/controlUserData';
+import { getOneUsersRec, loginUserData } from '../utils/controlUserData';
 import { useQueryClient } from '@tanstack/react-query';
 import { getAllUserLibRecs } from '../utils/controlBookData';
 
@@ -11,11 +11,17 @@ function App() {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    if (loginUserData)
+    if (loginUserData) {
       queryClient.prefetchQuery({
         queryKey: ['library', loginUserData],
         queryFn: getAllUserLibRecs,
       });
+
+      queryClient.prefetch({
+        queryKey: ['users', loginUserData],
+        queryFn: getOneUsersRec,
+      });
+    }
   }, [queryClient]);
 
   /* 앱 접근 시 로그인 여부와 'isSplashed', 'isInitialized' 상태 변수 값에 따른 action 결정 */

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -19,7 +19,7 @@ function App() {
 
       queryClient.prefetchQuery({
         queryKey: ['users', loginUserData],
-        queryFn: getOneUsersRec,
+        queryFn: () => getOneUsersRec(loginUserData.id),
       });
     }
   }, [queryClient]);

--- a/src/components/atoms/BookCoverInput/BookCoverInput.jsx
+++ b/src/components/atoms/BookCoverInput/BookCoverInput.jsx
@@ -9,12 +9,14 @@ function BookCoverInput({ title: bookTitle, cover: aladinBookImgUrl }) {
   const handleChange = async (e) => {
     const file = e.target.files[0];
 
-    try {
-      const imageURL = await convertFileToImgUrl(file);
-      setBookImgUrl(imageURL);
-    } catch (e) {
-      console.error(e);
-    }
+    await convertFileToImgUrl(file).then(
+      ((imgUrl) => {
+        setBookImgUrl(imgUrl);
+      },
+      (errMsg) => {
+        alert(errMsg);
+      })
+    );
   };
 
   if (bookImgUrl)

--- a/src/components/atoms/PwdVisibleIcon/PwdVisibleIcon.jsx
+++ b/src/components/atoms/PwdVisibleIcon/PwdVisibleIcon.jsx
@@ -1,0 +1,22 @@
+import { bool, func } from 'prop-types';
+
+function PwdVisibleIcon({ isVisible, onClick }) {
+  return (
+    <img
+      className="absolute w-4 top-10 right-5"
+      src={
+        isVisible
+          ? '/images/icons/password-eye.svg'
+          : '/images/icons/state=hidden.svg'
+      }
+      onClick={onClick}
+    />
+  );
+}
+
+PwdVisibleIcon.propTypes = {
+  isVisible: bool.isRequired,
+  onClick: func.isRequired,
+};
+
+export default PwdVisibleIcon;

--- a/src/components/atoms/PwdVisibleIcon/PwdVisibleIcon.stories.js
+++ b/src/components/atoms/PwdVisibleIcon/PwdVisibleIcon.stories.js
@@ -1,0 +1,16 @@
+import PwdVisibleIcon from './PwdVisibleIcon';
+
+const metaConfig = {
+  title: 'components/PwdVisibleIcon',
+  component: PwdVisibleIcon,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export default metaConfig;
+
+export const Base = {
+  args: {},
+};
+
+Base.storyName = 'PwdVisibleIcon';

--- a/src/components/molecules/BookBlock/BookBlock.jsx
+++ b/src/components/molecules/BookBlock/BookBlock.jsx
@@ -14,7 +14,6 @@ const getClassNames = (index) => {
     return 'w-[230px] border rounded-sm border-grayscale-white bg-badge-yellow-02 text-primary-500';
 };
 
-// 페이지 별 키(key)에 설정할 높이를 아래처럼 작성합니다.
 const BookBlock = memo(function BookBlock({
   title,
   page,
@@ -22,7 +21,6 @@ const BookBlock = memo(function BookBlock({
   id,
   isLoading,
 }) {
-  // 마크업 반환 (병합된 클래스 이름 설정)
   return isLoading ? (
     <li>
       <Skeleton

--- a/src/components/molecules/SearchBar/SearchBar.jsx
+++ b/src/components/molecules/SearchBar/SearchBar.jsx
@@ -5,7 +5,10 @@ import ResetBtn from '../../atoms/ResetBtn/ResetBtn';
 
 function SearchBar({ query, onQueryChange, onResetClick, pgName }) {
   return (
-    <form className="bg-grayscale-white w-full flex justify-between items-center gap-2 rounded border border-primary-500 px-3 py-2 ">
+    <form
+      className="bg-grayscale-white w-full flex justify-between items-center gap-2 rounded border border-primary-500 px-3 py-2 "
+      onSubmit={(e) => e.preventDefault()}
+    >
       <SearchIcon />
       <SearchInput query={query} onChange={onQueryChange} pgName={pgName} />
       {query === '' ? null : <ResetBtn onClick={onResetClick} />}

--- a/src/components/molecules/SearchBar/SearchBar.jsx
+++ b/src/components/molecules/SearchBar/SearchBar.jsx
@@ -1,13 +1,18 @@
+import { useCallback } from 'react';
 import { string, func, oneOf } from 'prop-types';
-import SearchInput from '../../atoms/SearchInput/SearchInput';
-import SearchIcon from '../../atoms/SearchIcon/SearchIcon';
 import ResetBtn from '../../atoms/ResetBtn/ResetBtn';
+import SearchIcon from '../../atoms/SearchIcon/SearchIcon';
+import SearchInput from '../../atoms/SearchInput/SearchInput';
 
 function SearchBar({ query, onQueryChange, onResetClick, pgName }) {
+  const handleSubmit = useCallback((e) => {
+    e.preventDefault();
+  }, []);
+
   return (
     <form
       className="bg-grayscale-white w-full flex justify-between items-center gap-2 rounded border border-primary-500 px-3 py-2 "
-      onSubmit={(e) => e.preventDefault()}
+      onSubmit={handleSubmit}
     >
       <SearchIcon />
       <SearchInput query={query} onChange={onQueryChange} pgName={pgName} />

--- a/src/components/organisms/Bookshelf/Bookshelf.jsx
+++ b/src/components/organisms/Bookshelf/Bookshelf.jsx
@@ -5,8 +5,8 @@ import SearchBar from '../../molecules/SearchBar/SearchBar';
 import ReadingStateFilter from '../../molecules/ReadingStateFilter/ReadingStateFilter';
 import { getAllUserLibRecs } from '../../../utils/controlBookData';
 import { loginUserData } from '../../../utils/controlUserData';
-import { useQuery } from '@tanstack/react-query';
 import debounce from '../../../utils/debounce';
+import { useQueryWithErr } from '../../../hooks/useQueryWithErr';
 
 function Bookshelf() {
   /* 책장 페이지에 필요한 데이터를 debouncedQuery로 요청
@@ -14,7 +14,7 @@ function Bookshelf() {
   const [localQuery, setLocalQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
 
-  const { data, isLoading, error, failureCount, failureReason } = useQuery({
+  const { data, isLoading } = useQueryWithErr({
     queryKey: ['library', loginUserData],
     queryFn: getAllUserLibRecs,
     select: (userLibRecs) => {
@@ -25,12 +25,6 @@ function Bookshelf() {
         );
     },
   });
-
-  // 쿼리 요청 실패 횟수와 실패 이유를 기준으로 error throwing 기능 구현
-  if (failureCount >= 1 && failureReason.message.startsWith('Server'))
-    throw error;
-
-  if (failureCount === 4) throw error;
 
   const updateDebouncedQuery = useMemo(
     () =>

--- a/src/components/organisms/CharacterCollection/CharacterCollection.jsx
+++ b/src/components/organisms/CharacterCollection/CharacterCollection.jsx
@@ -13,7 +13,7 @@ function CharacterCollection() {
     failureReason,
   } = useQuery({
     queryKey: ['users', loginUserData],
-    queryFn: getOneUsersRec,
+    queryFn: () => getOneUsersRec(loginUserData.id),
   });
 
   // 쿼리 요청 실패 횟수와 실패 이유를 기준으로 error throwing 기능 구현

--- a/src/components/organisms/CharacterCollection/CharacterCollection.jsx
+++ b/src/components/organisms/CharacterCollection/CharacterCollection.jsx
@@ -2,25 +2,14 @@ import { useState } from 'react';
 import UserCharacterCard from '../../molecules/UserCharacterCard/UserCharacterCard';
 import CharacterList from './../../molecules/CharacterList/CharacterList';
 import { calcLevel } from '../../../utils/calcLevel';
-import { useQuery } from '@tanstack/react-query';
 import { getOneUsersRec, loginUserData } from '../../../utils/controlUserData';
+import { useQueryWithErr } from '../../../hooks/useQueryWithErr';
 
 function CharacterCollection() {
-  const {
-    data: userRec,
-    error,
-    failureCount,
-    failureReason,
-  } = useQuery({
+  const { data: userRec } = useQueryWithErr({
     queryKey: ['users', loginUserData],
     queryFn: () => getOneUsersRec(loginUserData.id),
   });
-
-  // 쿼리 요청 실패 횟수와 실패 이유를 기준으로 error throwing 기능 구현
-  if (failureCount >= 1 && failureReason.message.startsWith('Server'))
-    throw error;
-
-  if (failureCount === 4) throw error;
 
   const userLv = calcLevel(userRec?.['book_height'] * 1 || 0) || 1;
   const [clickedLv, setClickedLv] = useState(userLv);

--- a/src/components/organisms/CharacterCollection/CharacterCollection.jsx
+++ b/src/components/organisms/CharacterCollection/CharacterCollection.jsx
@@ -1,11 +1,27 @@
 import { useState } from 'react';
 import UserCharacterCard from '../../molecules/UserCharacterCard/UserCharacterCard';
 import CharacterList from './../../molecules/CharacterList/CharacterList';
-import { useLoaderData } from 'react-router-dom';
 import { calcLevel } from '../../../utils/calcLevel';
+import { useQuery } from '@tanstack/react-query';
+import { getOneUsersRec, loginUserData } from '../../../utils/controlUserData';
 
 function CharacterCollection() {
-  const userRec = useLoaderData();
+  const {
+    data: userRec,
+    error,
+    failureCount,
+    failureReason,
+  } = useQuery({
+    queryKey: ['users', loginUserData],
+    queryFn: getOneUsersRec,
+  });
+
+  // 쿼리 요청 실패 횟수와 실패 이유를 기준으로 error throwing 기능 구현
+  if (failureCount >= 1 && failureReason.message.startsWith('Server'))
+    throw error;
+
+  if (failureCount === 4) throw error;
+
   const userLv = calcLevel(userRec?.['book_height'] * 1 || 0) || 1;
   const [clickedLv, setClickedLv] = useState(userLv);
   const handleClick = (e) => {

--- a/src/components/organisms/MemoList/MemoList.stories.js
+++ b/src/components/organisms/MemoList/MemoList.stories.js
@@ -1,8 +1,5 @@
 import MemoList from './MemoList';
 
-// 이 레벨의 테스트를 위해선 msw가 필요하겠네요.
-// https://mswjs.io/
-// https://storybook.js.org/addons/msw-storybook-addon
 const metaConfig = {
   title: 'components/MemoList',
   component: MemoList,

--- a/src/components/pages/MypagePage.jsx
+++ b/src/components/pages/MypagePage.jsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import {
   clearLoginUserData,
   withdrawUser,
@@ -10,12 +10,11 @@ import CharacterImg from '../atoms/CharacterImg/CharacterImg';
 import CharacterName from '../atoms/CharacterName/CharacterName';
 import CharacterLevel from '../atoms/CharacterLevel/CharacterLevel';
 import { Helmet } from 'react-helmet-async';
-import { Link } from 'react-router-dom';
 import A11yHidden from '../atoms/A11yHidden/A11yHidden';
 import pb from '../../api/pocketbase';
 import { calcLevel } from '../../utils/calcLevel';
-import { useQuery } from '@tanstack/react-query';
 import BookInfo from '../molecules/BookInfo/BookInfo';
+import { useQuery } from '@tanstack/react-query';
 
 function MypagePage() {
   const navigate = useNavigate();

--- a/src/components/pages/MypagePage.jsx
+++ b/src/components/pages/MypagePage.jsx
@@ -3,6 +3,7 @@ import {
   clearLoginUserData,
   withdrawUser,
   loginUserData,
+  getOneUsersRec,
 } from '../../utils/controlUserData';
 import LargeHeader from '/src/components/organisms/Header/LargeHeader/LargeHeader';
 import CharacterImg from '../atoms/CharacterImg/CharacterImg';
@@ -11,10 +12,10 @@ import CharacterLevel from '../atoms/CharacterLevel/CharacterLevel';
 import TotalBookHeight from '../atoms/TotalBookHeight/TotalBookHeight';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
-import { useLoaderData } from 'react-router-dom';
 import A11yHidden from '../atoms/A11yHidden/A11yHidden';
 import pb from '../../api/pocketbase';
 import { calcLevel } from '../../utils/calcLevel';
+import { useQuery } from '@tanstack/react-query';
 
 function MypagePage() {
   const navigate = useNavigate();
@@ -50,7 +51,23 @@ function MypagePage() {
 
   const loginUserNickName = loginUserData.nickname;
   const loginUserEmail = loginUserData.email;
-  const userRec = useLoaderData();
+
+  const {
+    data: userRec,
+    error,
+    failureCount,
+    failureReason,
+  } = useQuery({
+    queryKey: ['users', loginUserData],
+    queryFn: getOneUsersRec,
+  });
+
+  // 쿼리 요청 실패 횟수와 실패 이유를 기준으로 error throwing 기능 구현
+  if (failureCount >= 1 && failureReason.message.startsWith('Server'))
+    throw error;
+
+  if (failureCount === 4) throw error;
+
   const userBookHeight = userRec?.['book_height'] * 1 || 0;
   const userLevel = calcLevel(userBookHeight) || 1;
   const doneBookNum = userRec?.['done_book'] * 1 || 0;

--- a/src/components/pages/MypagePage.jsx
+++ b/src/components/pages/MypagePage.jsx
@@ -14,7 +14,7 @@ import A11yHidden from '../atoms/A11yHidden/A11yHidden';
 import pb from '../../api/pocketbase';
 import { calcLevel } from '../../utils/calcLevel';
 import BookInfo from '../molecules/BookInfo/BookInfo';
-import { useQuery } from '@tanstack/react-query';
+import { useQueryWithErr } from '../../hooks/useQueryWithErr';
 
 function MypagePage() {
   const navigate = useNavigate();
@@ -51,21 +51,10 @@ function MypagePage() {
   const loginUserNickName = loginUserData.nickname;
   const loginUserEmail = loginUserData.email;
 
-  const {
-    data: userRec,
-    error,
-    failureCount,
-    failureReason,
-  } = useQuery({
+  const { data: userRec } = useQueryWithErr({
     queryKey: ['users', loginUserData],
     queryFn: () => getOneUsersRec(loginUserData.id),
   });
-
-  // 쿼리 요청 실패 횟수와 실패 이유를 기준으로 error throwing 기능 구현
-  if (failureCount >= 1 && failureReason.message.startsWith('Server'))
-    throw error;
-
-  if (failureCount === 4) throw error;
 
   const userBookHeight = userRec?.['book_height'] * 1 || 0;
   const userLevel = calcLevel(userBookHeight) || 1;

--- a/src/components/pages/MypagePage.jsx
+++ b/src/components/pages/MypagePage.jsx
@@ -58,7 +58,7 @@ function MypagePage() {
     failureReason,
   } = useQuery({
     queryKey: ['users', loginUserData],
-    queryFn: getOneUsersRec,
+    queryFn: () => getOneUsersRec(loginUserData.id),
   });
 
   // 쿼리 요청 실패 횟수와 실패 이유를 기준으로 error throwing 기능 구현

--- a/src/components/pages/MypagePage.jsx
+++ b/src/components/pages/MypagePage.jsx
@@ -1,20 +1,20 @@
-import { useNavigate, Link } from 'react-router-dom';
 import {
   clearLoginUserData,
   withdrawUser,
   loginUserData,
   getOneUsersRec,
 } from '../../utils/controlUserData';
-import LargeHeader from '/src/components/organisms/Header/LargeHeader/LargeHeader';
+import pb from '../../api/pocketbase';
+import { Helmet } from 'react-helmet-async';
+import { calcLevel } from '../../utils/calcLevel';
+import { useNavigate, Link } from 'react-router-dom';
+import BookInfo from '../molecules/BookInfo/BookInfo';
+import A11yHidden from '../atoms/A11yHidden/A11yHidden';
 import CharacterImg from '../atoms/CharacterImg/CharacterImg';
+import { useQueryWithErr } from '../../hooks/useQueryWithErr';
 import CharacterName from '../atoms/CharacterName/CharacterName';
 import CharacterLevel from '../atoms/CharacterLevel/CharacterLevel';
-import { Helmet } from 'react-helmet-async';
-import A11yHidden from '../atoms/A11yHidden/A11yHidden';
-import pb from '../../api/pocketbase';
-import { calcLevel } from '../../utils/calcLevel';
-import BookInfo from '../molecules/BookInfo/BookInfo';
-import { useQueryWithErr } from '../../hooks/useQueryWithErr';
+import LargeHeader from '/src/components/organisms/Header/LargeHeader/LargeHeader';
 
 function MypagePage() {
   const navigate = useNavigate();
@@ -32,20 +32,24 @@ function MypagePage() {
     }
   };
 
-  const handleWithdraw = async () => {
-    let isWithdrawn = false;
-
+  /* 회원 탈퇴 기능 handling 로직 */
+  const handleWithdraw = () => {
     const willWithdraw = confirm('정말로 탈퇴하시겠습니까?');
 
-    if (willWithdraw) {
-      await withdrawUser();
-      isWithdrawn = true;
-    }
+    if (!willWithdraw) return;
 
-    if (isWithdrawn) {
-      alert('회원 탈퇴가 완료되었습니다.');
-      navigate('/login');
-    }
+    withdrawUser().then(
+      () => {
+        alert('회원 탈퇴가 완료되었습니다.');
+
+        navigate('/login');
+      },
+      (err) => {
+        alert(err.message);
+
+        return;
+      }
+    );
   };
 
   const loginUserNickName = loginUserData.nickname;

--- a/src/components/pages/RegisterPage.jsx
+++ b/src/components/pages/RegisterPage.jsx
@@ -11,7 +11,6 @@ import { Helmet } from 'react-helmet-async';
 import FormInputBox from '../molecules/FormInputBox/FormInputBox';
 import { Link } from 'react-router-dom';
 
-// 이 페이지는 Form의 기능을 적극적으로 사용하는 것이 좋습니다.
 function RegisterPage() {
   // 초기값 세팅
   const [nickname, setNickname] = useState('');

--- a/src/components/pages/RegisterPage.jsx
+++ b/src/components/pages/RegisterPage.jsx
@@ -120,7 +120,12 @@ function RegisterPage() {
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    if (isNicknameValid && isEmailValid && isPwdValid && isConfirmPwdValid) {
+    if (
+      !isNicknameValid &&
+      !isEmailValid &&
+      !isPwdValid &&
+      !isConfirmPwdValid
+    ) {
       alert('정보가 올바르지 않습니다. 입력 값을 확인해주세요.');
 
       return;

--- a/src/components/pages/RegisterPage.jsx
+++ b/src/components/pages/RegisterPage.jsx
@@ -109,7 +109,7 @@ function RegisterPage() {
 
   const navigate = useNavigate();
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = (e) => {
     e.preventDefault();
 
     if (isNicknameValid && isEmailValid && isPwdValid && isConfirmPwdValid) {
@@ -118,14 +118,14 @@ function RegisterPage() {
       return;
     }
 
-    await signUpUser(nickname, email, password).then(
+    signUpUser(nickname, email, password).then(
       () => {
         alert('축하합니다! 로그인 페이지로 이동합니다.');
 
         navigate('/login');
       },
-      () => {
-        alert('에러가 발생하였습니다. 다시 시도하여주십시오.');
+      (err) => {
+        alert(err.message);
 
         return;
       }

--- a/src/components/pages/RegisterPage.jsx
+++ b/src/components/pages/RegisterPage.jsx
@@ -10,27 +10,13 @@ import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import FormInputBox from '../molecules/FormInputBox/FormInputBox';
 import { Link } from 'react-router-dom';
+import PwdVisibleIcon from '../atoms/PwdVisibleIcon/PwdVisibleIcon';
 
 function RegisterPage() {
-  // 초기값 세팅
+  /* Nickname 입력 관련 input 요소 제어 및 값 validation */
   const [nickname, setNickname] = useState('');
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirmPwd, setConfirmPwd] = useState('');
-
-  // 오류메세지 상태
   const [nicknameErrorMsg, setNicknameErrorMsg] = useState('');
-  const [emailErrorMsg, setEmailErrorMsg] = useState('');
-  const [PwdErrorMsg, setPwdErrorMsg] = useState('');
-  const [confirmPwdErrorMsg, setConfirmPwdErrorMsg] = useState('');
-
-  // 유효성 검사
   const [isNicknameValid, setIsNicknameValid] = useState(false);
-  const [isEmailValid, setIsEmailValid] = useState(false);
-  const [isPwdValid, setIsPwdValid] = useState(false);
-  const [isConfirmPwdValid, setIsConfirmPwdValid] = useState(false);
-
-  // onchange 닉네임
 
   const onChangeNickname = debounce(async (e) => {
     const currentNickname = e.target.value;
@@ -51,7 +37,10 @@ function RegisterPage() {
     }
   });
 
-  // onchange 이메일
+  /* Email 입력 관련 input 요소 제어 및 값 validation */
+  const [email, setEmail] = useState('');
+  const [emailErrorMsg, setEmailErrorMsg] = useState('');
+  const [isEmailValid, setIsEmailValid] = useState(false);
 
   const onChangeEmail = debounce(async (e) => {
     const currentEmail = e.target.value;
@@ -74,7 +63,10 @@ function RegisterPage() {
     }
   });
 
-  // onchange 비밀번호
+  /* Password 입력 관련 input 요소 제어 및 값 validation */
+  const [password, setPassword] = useState('');
+  const [PwdErrorMsg, setPwdErrorMsg] = useState('');
+  const [isPwdValid, setIsPwdValid] = useState(false);
 
   const onChangePwd = (e) => {
     const currentPwd = e.target.value;
@@ -90,7 +82,10 @@ function RegisterPage() {
     }
   };
 
-  // onchange 비밀번호 확인
+  /* Password 확인용 값 입력 관련 input 요소 제어 및 validation */
+  const [confirmPwd, setConfirmPwd] = useState('');
+  const [confirmPwdErrorMsg, setConfirmPwdErrorMsg] = useState('');
+  const [isConfirmPwdValid, setIsConfirmPwdValid] = useState(false);
 
   const onChangeConfirm = (e) => {
     const currentConfirm = e.target.value;
@@ -105,8 +100,21 @@ function RegisterPage() {
     }
   };
 
-  // DB로 보내기
+  /* Pwd 값 visibility 조절 로직 */
+  const [pwdInfo, setPwdInfo] = useState({
+    type: 'password',
+    visible: false,
+  });
 
+  const handlePwdInfo = () => {
+    setPwdInfo((prevPwInfo) => {
+      if (!prevPwInfo.visible) return { type: 'text', visible: true };
+
+      return { type: 'password', visible: false };
+    });
+  };
+
+  /* 회원가입 데이터 PB 서버로 submit 후 사용자 redirect */
   const navigate = useNavigate();
 
   const handleSubmit = (e) => {
@@ -130,25 +138,6 @@ function RegisterPage() {
         return;
       }
     );
-  };
-
-  // 클릭 시 비밀번호 보이게
-  const [pwType, setpwType] = useState({
-    type: 'password',
-    visible: false,
-  });
-
-  const handlePasswordType = () => {
-    setpwType(() => {
-      // 만약 현재 pwType.visible이 false 라면
-      if (!pwType.visible) {
-        return { type: 'text', visible: true };
-
-        //현재 pwType.visible이 true 라면
-      } else {
-        return { type: 'password', visible: false };
-      }
-    });
   };
 
   return (
@@ -212,7 +201,7 @@ function RegisterPage() {
                 label="비밀번호"
                 id="password"
                 name="password"
-                type={pwType.type}
+                type={pwdInfo.type}
                 value={password}
                 placeholder="비밀번호를 입력해주세요"
                 onChange={onChangePwd}
@@ -227,15 +216,10 @@ function RegisterPage() {
                 {PwdErrorMsg}
               </p>
             </div>
-            <img
-              className="absolute w-4 top-10 right-5"
-              src={
-                pwType.visible
-                  ? '/images/icons/password-eye.svg'
-                  : '/images/icons/state=hidden.svg'
-              }
-              onClick={handlePasswordType}
-            ></img>
+            <PwdVisibleIcon
+              isVisible={pwdInfo.visible}
+              onClick={handlePwdInfo}
+            />
           </div>
           <div>
             <FormInputBox

--- a/src/hooks/useQueryWithErr.js
+++ b/src/hooks/useQueryWithErr.js
@@ -1,0 +1,120 @@
+import { useQuery } from '@tanstack/react-query';
+
+// 해당 커스텀 훅에서 받는 인자와 return 값은 TanStack Query에서 제공하는 useQuery가 받는 인자, 그리고 return 값과 완전히 같음.
+// TanStack Query 내 'useQuery' 사용법 링크 : https://tanstack.com/query/latest/docs/framework/react/reference/useQuery#usequery
+// fetching 관련 error handling 로직 강화 필요
+export function useQueryWithErr(
+  {
+    queryKey,
+    queryFn,
+    gcTime,
+    enabled,
+    networkMode,
+    initialData,
+    initialDataUpdatedAt,
+    meta,
+    notifyOnChangeProps,
+    placeholderData,
+    queryKeyHashFn,
+    refetchInterval,
+    refetchIntervalInBackground,
+    refetchOnMount,
+    refetchOnReconnect,
+    refetchOnWindowFocus,
+    retry,
+    retryOnMount,
+    retryDelay,
+    select,
+    staleTime,
+    structuralSharing,
+    throwOnError,
+  },
+  queryClient
+) {
+  const {
+    data,
+    dataUpdatedAt,
+    error,
+    errorUpdatedAt,
+    failureCount,
+    failureReason,
+    fetchStatus,
+    isError,
+    isFetched,
+    isFetchedAfterMount,
+    isFetching,
+    isInitialLoading,
+    isLoading,
+    isLoadingError,
+    isPaused,
+    isPending,
+    isPlaceholderData,
+    isRefetchError,
+    isRefetching,
+    isStale,
+    isSuccess,
+    promise,
+    refetch,
+    status,
+  } = useQuery(
+    {
+      queryKey,
+      queryFn,
+      gcTime,
+      enabled,
+      networkMode,
+      initialData,
+      initialDataUpdatedAt,
+      meta,
+      notifyOnChangeProps,
+      placeholderData,
+      queryKeyHashFn,
+      refetchInterval,
+      refetchIntervalInBackground,
+      refetchOnMount,
+      refetchOnReconnect,
+      refetchOnWindowFocus,
+      retry,
+      retryOnMount,
+      retryDelay,
+      select,
+      staleTime,
+      structuralSharing,
+      throwOnError,
+    },
+    queryClient
+  );
+
+  // 쿼리 요청 실패 횟수와 실패 이유를 기준으로 error throwing 기능 구현
+  if (failureCount >= 1 && failureReason.message.startsWith('Server'))
+    throw error;
+
+  if (failureCount === 4) throw error;
+
+  return {
+    data,
+    dataUpdatedAt,
+    error,
+    errorUpdatedAt,
+    failureCount,
+    failureReason,
+    fetchStatus,
+    isError,
+    isFetched,
+    isFetchedAfterMount,
+    isFetching,
+    isInitialLoading,
+    isLoading,
+    isLoadingError,
+    isPaused,
+    isPending,
+    isPlaceholderData,
+    isRefetchError,
+    isRefetching,
+    isStale,
+    isSuccess,
+    promise,
+    refetch,
+    status,
+  };
+}

--- a/src/utils/controlUserData.js
+++ b/src/utils/controlUserData.js
@@ -141,6 +141,21 @@ export async function putUserNewLevel(newUserLevel) {
 }
 
 /* -------------------------------------------- */
+/*           'users' col record fetch           */
+/* -------------------------------------------- */
+
+/**
+ * 'users' collection에서 하나의 record를 불러오는 함수
+ * @param { string } recId 'users' collection record ID
+ * @param { Object } [options] PocketBase SDK 내 read를 위한 query options
+ * @prop { string } [expand] [PocketBase 공식 문서](https://pocketbase.io/docs/) 참고
+ * @prop { string } [fields] [PocketBase 공식 문서](https://pocketbase.io/docs/) 참고
+ * @returns 'users' collection의 record 객체
+ */
+export const getOneUsersRec = async (recId, options) =>
+  await pb.collection('users').getOne(recId, options);
+
+/* -------------------------------------------- */
 /*               인증된 유저 정보                */
 /* -------------------------------------------- */
 

--- a/src/utils/controlUserData.js
+++ b/src/utils/controlUserData.js
@@ -73,11 +73,17 @@ export async function signUpUser(nickname, email, password) {
  * * 로그인된 회원의 id를 가져와 회원탈퇴를 하는 함수
  */
 export async function withdrawUser() {
-  if (loginUserData) {
-    return await pb.collection('users').delete(loginUserData.id);
+  if (!loginUserData) {
+    alert('로그인 데이터가 없습니다.');
+
+    return;
   }
 
-  return alert('통신 오류입니다. 다시 시도해주시길 바랍니다.');
+  try {
+    await pb.collection('users').delete(loginUserData.id);
+  } catch {
+    throw new Error('통신 오류입니다. 다시 시도해주시길 바랍니다.');
+  }
 }
 
 /**

--- a/src/utils/controlUserData.js
+++ b/src/utils/controlUserData.js
@@ -61,9 +61,10 @@ export async function signUpUser(nickname, email, password) {
 
   try {
     const record = await pb.collection('users').create(data);
+
     return record;
-  } catch (error) {
-    return false;
+  } catch {
+    throw new Error('에러가 발생하였습니다. 다시 시도하여주십시오.');
   }
 }
 


### PR DESCRIPTION
## PR 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 내용 요약

- 앱 접근 시 앱에 로그인 한 유저 정보가 PocketBase instance 내에 존재할 경우 로그인 한 유저의 DB 내 record ( 'users' collection 내 record ) 를 prefetch 하는 기능 구현
- 캐릭터 페이지, 마이페이지 내 로그인 한 유저의 정보를 fetch 해오는 코드를 TanStack Query의 useQuery를 이용하여 구현
- useQuery로 서버의 data fetch 시 발생할 수 있는 오류 handling 코드를 `useQueryWithErr` 커스텀 훅에 집어넣어 코드의 가독성 강화
- 마이페이지 내 코드의 SoC ( Separation of Concern ) 진행
- 마이페이지 내 비밀번호 입력 input 값 visibility를 조절하는 icon 컴포넌트화 진행
- 책장 페이지와 책 검색 페이지 내 검색 바에서 사용자가 enter를 눌렀을 때 의도하지 않게 submit이 되면서 화면이 새로고침 되는 현상 제거
- BookCoverInput에서 로컬 컴퓨터 내에 있는 image file 등록 시 발생할 수 있는 error handling 로직 수정
- RegisterPage 내 비동기로 서버 데이터 create 시 발생할 수 있는 error handling 로직 변경
- MypagePage 내 비동기로 서버 데이터 delete 시 발생할 수 있는 error handling 로직 변경

### PR 상세

- [controlUserData.js 내 getOneUsersRec 유틸 함수 생성](https://github.com/FRONTENDSCHOOL8/Book-Kong/commit/227a0cb466462cbb8af49b7d0e3b76cc58b64b41)
- App.jsx 내 TanStack Query의 queryClient를 이용한 'users' collection 내 로그인 한 유저의 record prefetch 코드 작성
- 마이페이지에 들어가는 `PwdVisibleIcon` 컴포넌트 생성
- SearchBar 컴포넌트 내 `form` 태그에 onSubmit 값으로 이벤트 객체를 받아 preventDefault 메소드를 실행시키는 함수 입력
- BookCoverInput에서 사용자 조작으로 인한 cover change 시 promise 객체를 반환하는 함수의 실행 오류를 handling하는 코드 수정
- RegisterPage, MypagePage에서 서버 데이터를 변경하기 위해 실행시키는 비동기 함수의 값으로 promise 객체가 나오는 것을 이용하여 error handling 로직 수정
- 기타 변경 사항 `Commits` 및 `Files changed` 참고

### 스크린샷

- 캐릭터 페이지 내 user data를 router의 `loader` props로 공급 시 네트워크 지연 시간 및 UX

  ![Honeycam 2024-11-12 12-35-35](https://github.com/user-attachments/assets/9f56af1b-cf55-4ac6-8f5c-7b1d2778da18)

  - Fetching 시간 1.03 s

- 마이페이지 내 user data를 router의 `loader` props로 공급 시 네트워크 지연 시간 및 UX

  ![Honeycam 2024-11-12 12-38-11](https://github.com/user-attachments/assets/12e08bba-ecd6-4dfa-bc24-4b93202ea26e)

  - Fetching 시간 1.26 s

- App 초기 접근 시 user data를 prefetch 했을 때 캐릭터 페이지와 마이페이지에서 cached data 사용 gif

  ![Honeycam 2024-11-12 12-42-11](https://github.com/user-attachments/assets/6d99c2cb-7b11-4eb3-aaa6-a1ee4a02d10c)

  - 사용자가 변하지 않은 user data ( PocketBase DB 내 user record ) 를 네트워크 지연 시간 없이 사용 가능
  - 사용자의 `users` collection 내 data를 불러오는 useQuery의 staleTime을 `0 s` 로 설정해놓아 해당 페이지들 접근 시마다 데이터를 새로 fetch하는 문제는 추후 개선 예정

## 이슈

close #216 